### PR TITLE
feat(KONFLUX-4158): add fbc-fips-check task to FBC pipeline

### DIFF
--- a/.tekton/cnv-fbc-ynanavat-pull-request.yaml
+++ b/.tekton/cnv-fbc-ynanavat-pull-request.yaml
@@ -277,6 +277,30 @@ spec:
         operator: in
         values:
         - "true"
+    - name: fbc-fips-check-oci-ta
+      params:
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: fbc-fips-check-oci-ta
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta:0.1@sha256:2e6900f5755fca70f8eebfcf004f39dd9adf6b488c8828f35a1b24862a9f81cf
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     - name: deprecated-base-image-check
       params:
       - name: IMAGE_URL

--- a/.tekton/fbc-pipeline-ynanavat.yaml
+++ b/.tekton/fbc-pipeline-ynanavat.yaml
@@ -237,6 +237,31 @@ spec:
       operator: in
       values:
       - "true"
+  - name: fbc-fips-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: fbc-fips-check
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check:0.1@sha256:03e9fd8c7c7fdcb8c965333fa7b2ea83e75da766f5ecd92cbc02ae4a92b2e247
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces:
+    - name: workspace
+      workspace: workspace
   - name: deprecated-base-image-check
     params:
     - name: IMAGE_URL

--- a/.tekton/fbc-pipeline.yaml
+++ b/.tekton/fbc-pipeline.yaml
@@ -236,6 +236,31 @@ spec:
       operator: in
       values:
       - "true"
+  - name: fbc-fips-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: fbc-fips-check
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-fbc-fips-check:0.1@sha256:03e9fd8c7c7fdcb8c965333fa7b2ea83e75da766f5ecd92cbc02ae4a92b2e247
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces:
+    - name: workspace
+      workspace: workspace
   - name: deprecated-base-image-check
     params:
     - name: IMAGE_URL

--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: operator.openshift.io/v1alpha1
+kind: ImageDigestMirrorSet
+metadata:
+  name: example-mirror-set
+spec:
+  imageDigestMirrors:
+    - mirrors:
+        - quay.io/my-namespace/valid-repo
+      source: registry.redhat.io/unrelease-image/or-inaccessible-image


### PR DESCRIPTION
This commit adds the fbc-fips-check to the FBC pipeline. It also adds a template file named images-mirror-set.yaml which is required by the FIPS task itself and will be used by other tasks in the future.